### PR TITLE
fixed terrain collider issuesd

### DIFF
--- a/engine/scene/components/HeightmapCollider.cpp
+++ b/engine/scene/components/HeightmapCollider.cpp
@@ -3,6 +3,7 @@
 #include <btBulletDynamicsCommon.h>
 #include <BulletCollision/CollisionShapes/btHeightfieldTerrainShape.h>
 #include <cassert>
+#include <vector>
 #include "physics/PhysicsSystem.h"
 #include "scene/Scene.h"
 #include "scene/Object.h"
@@ -22,24 +23,42 @@ namespace engine
         assert(heightmap && "HeightmapCollider requires height data");
 
         PhysicsSystem* physics = owner->getScene()->getPhysicsSystem();
+
+        const auto& sourceHeights = heightmap->getHeightData();
+
+        _scaledHeightData.resize(sourceHeights.size());
+        for (std::size_t i = 0; i < sourceHeights.size(); ++i)
+        {
+            _scaledHeightData[i] = sourceHeights[i] * heightmap->getHeightScale();
+        }
+
         _shape = std::make_unique<btHeightfieldTerrainShape>(
-            heightmap->getWidth(), heightmap->getLength(),
-            heightmap->getHeightData().data(), 1.0f,
-            0.0f, heightmap->getHeightScale(), 1, PHY_FLOAT, false
+            heightmap->getWidth(),
+            heightmap->getLength(),
+            _scaledHeightData.data(),
+            1.0f,
+            0.0f,
+            heightmap->getHeightScale(),
+            1,
+            PHY_FLOAT,
+            false
         );
 
-        // Set local scaling to match terrain mesh resolution and size
         float planeRes = static_cast<float>(heightmap->getWidth() - 1);
-        float doubleScale = planeLen / planeRes;
-        _shape->setLocalScaling(btVector3(doubleScale, 1.0f, doubleScale));
+        float terrainScale = planeLen / planeRes;
 
-        // Bullet heightmap terrain shape spans [-halfHeight, halfHeight]
-        // Shift the collision object by halfHeight to align with the visual mesh
-        float halfHeight = heightmap->getHeightScale() * 0.5f;
+        _shape->setLocalScaling(btVector3(
+            terrainScale,
+            1.0f,
+            terrainScale
+        ));
+
         glm::vec3 worldPos = owner->transform.getWorldPosition();
-        worldPos.y += halfHeight;
 
-        // Register as static collision object
+        // Bullet centers the heightfield around (minHeight + maxHeight) / 2.
+        // Your visual mesh is 0 -> heightScale, so shift the object up by half.
+        worldPos.y += heightmap->getHeightScale() * 0.5f;
+
         _object = physics->createCollisionObject(_shape.get(), worldPos, false);
     }
 
@@ -51,21 +70,24 @@ namespace engine
         }
 
         glm::vec3 worldScale = owner->transform.getWorldScale();
-        float planeRes = static_cast<float>(heightmap->getWidth() - 1);
-        float doubleScale = planeLen / planeRes;
-        _shape->setLocalScaling(btVector3(
-            doubleScale * worldScale.x,
-            worldScale.y,
-            doubleScale * worldScale.z
-        ));
 
-        btTransform t;
-        t.setIdentity();
+        float planeRes = static_cast<float>(heightmap->getWidth() - 1);
+        float terrainScale = planeLen / planeRes;
+
+        _shape->setLocalScaling(btVector3(
+            terrainScale * worldScale.x,
+            worldScale.y,
+            terrainScale * worldScale.z
+        ));
 
         glm::vec3 worldPos = owner->transform.getWorldPosition();
         worldPos.y += heightmap->getHeightScale() * 0.5f * worldScale.y;
+
+        btTransform t;
+        t.setIdentity();
         t.setOrigin(PhysicsSystem::toBullet(worldPos));
         t.setRotation(PhysicsSystem::toBullet(owner->transform.getWorldRotation()));
+
         _object->setWorldTransform(t);
     }
 }

--- a/engine/scene/components/HeightmapCollider.h
+++ b/engine/scene/components/HeightmapCollider.h
@@ -27,5 +27,6 @@ namespace engine
 
     private:
         std::unique_ptr<btHeightfieldTerrainShape> _shape;
+        std::vector<float> _scaledHeightData;        
     };
 }


### PR DESCRIPTION
Bullet is not scaling your float height data the way we assumed.
Heightmap::_heightData stores normalized values:

0.0 → 1.0

Your visual mesh does this:

heightmap.sample(u, v) * heightmap.getHeightScale()

So visually the terrain is:

0.0 → 400.0

But btHeightfieldTerrainShape with PHY_FLOAT reads the float values directly. The heightScale argument does not scale float height data the way it does for integer heightfields.